### PR TITLE
Add basic texture support

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -109,7 +109,7 @@ pub struct Vertex3 {
     /// The coordinates in texture space associated with this vertex (the UV-mapping of the vertex).
     ///
     /// This value is ignored when no texture is used.
-    pub uv: [Float; 2],
+    pub texture_coords: [Float; 2],
 }
 
 /// A vertex of a 2D [`Primitive2`].
@@ -130,7 +130,7 @@ pub struct Vertex2 {
     /// The coordinates in texture space associated with this vertex (the UV-mapping of the vertex).
     ///
     /// This value is ignored when no texture is used.
-    pub uv: [Float; 2],
+    pub texture_coords: [Float; 2],
 }
 
 /// The simplest 3D object that can be drawn to the screen directly.
@@ -179,8 +179,9 @@ impl Gui {
         &mut self,
         vertices: &[Vertex3],
         indices: &[Index],
+        texture: Rc<Texture>,
     ) -> Result<Primitive3, PrimitiveError> {
-        self.backend.make_primitive3(vertices, indices)
+        self.backend.make_primitive3(vertices, indices, texture)
     }
 
     /// Creates a new [2D graphics primitive](Primitive2) from raw components.
@@ -188,8 +189,9 @@ impl Gui {
         &mut self,
         vertices: &[Vertex2],
         indices: &[Index],
+        texture: Rc<Texture>,
     ) -> Result<Primitive2, PrimitiveError> {
-        self.backend.make_primitive2(vertices, indices)
+        self.backend.make_primitive2(vertices, indices, texture)
     }
 }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -22,9 +22,17 @@ pub mod asset;
 ///
 /// ## See also
 /// backend::run
-pub struct Gui(backend::Gui);
+pub struct Gui {
+    /// The implementation provided by the backend.
+    backend: backend::Gui,
+}
 
-impl Gui {}
+impl Gui {
+    /// Wraps the provided backend implementation of Gui with the public-facing type.
+    fn from(backend: backend::Gui) -> Self {
+        Self { backend }
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Drawing basics
@@ -158,7 +166,7 @@ impl Gui {
         vertices: &[Vertex3],
         indices: &[Index],
     ) -> Result<Primitive3, PrimitiveError> {
-        self.0.make_primitive3(vertices, indices)
+        self.backend.make_primitive3(vertices, indices)
     }
 
     /// Creates a new [2D graphics primitive](Primitive2) from raw components.
@@ -167,6 +175,6 @@ impl Gui {
         vertices: &[Vertex2],
         indices: &[Index],
     ) -> Result<Primitive2, PrimitiveError> {
-        self.0.make_primitive2(vertices, indices)
+        self.backend.make_primitive2(vertices, indices)
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -247,9 +247,12 @@ impl Gui {
             }
         }
 
-        let image = asset::load_image(id.name);
-        let texture = Rc::new(self.backend.make_texture(image, &id));
-        self.texture_registry.insert(id, Rc::downgrade(&texture));
-        texture
+        let name = id.name;
+        crate::crash::with_context(("Loading texture", || name), || {
+            let image = asset::load_image(id.name);
+            let texture = Rc::new(self.backend.make_texture(image, &id));
+            self.texture_registry.insert(id, Rc::downgrade(&texture));
+            texture
+        })
     }
 }

--- a/src/gui/asset.rs
+++ b/src/gui/asset.rs
@@ -59,7 +59,7 @@ fn load_asset(req: AssetLoadRequest) -> std::io::Cursor<&[u8]> {
 /// The name must match regex `[A-Za-z_]+`, otherwise this function panics.
 ///
 /// Missing data, IO errors, decoding errors, allocation errors all result in a panic.
-pub fn load_image(name: &str) -> image::RgbaImage {
+pub fn load_image(name: &str) -> image::DynamicImage {
     let cursor = load_asset(AssetLoadRequest {
         kind: "Image",
         location: "image",
@@ -67,8 +67,6 @@ pub fn load_image(name: &str) -> image::RgbaImage {
         suffix: ".png",
     });
 
-    let image = image::load(cursor, image::ImageFormat::Png)
-        .expect(&format!("Image {name:?} is not a valid PNG file"));
-
-    image.to_rgba8()
+    image::load(cursor, image::ImageFormat::Png)
+        .expect(&format!("Image {name:?} is not a valid PNG file"))
 }

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -63,7 +63,7 @@ impl Gui {
         )
         .expect("Could not create GLSL shared program");
 
-        super::Gui(Self {
+        super::Gui::from(Self {
             last_started_frame: 0,
             start_time: std::time::Instant::now(),
             program_3d,

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -217,3 +217,15 @@ impl Gui {
         Ok(super::Primitive2(Primitive2 { vertices, indices }))
     }
 }
+
+pub struct Texture;
+
+impl Gui {
+    pub fn make_texture(
+        &mut self,
+        image: image::DynamicImage,
+        id: &super::TextureId,
+    ) -> super::Texture {
+        unimplemented!()
+    }
+}

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -218,14 +218,21 @@ impl Gui {
     }
 }
 
-pub struct Texture;
+pub type Texture = glium::texture::Texture2d;
 
 impl Gui {
     pub fn make_texture(
         &mut self,
         image: image::DynamicImage,
-        id: &super::TextureId,
+        _id: &super::TextureId,
     ) -> super::Texture {
-        unimplemented!()
+        use glium::texture::{MipmapsOption, RawImage2d, Texture2d};
+
+        let image = image.to_rgba8();
+        let image_dimensions = image.dimensions();
+        let image = RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
+        let texture = Texture2d::with_mipmaps(&self.display, image, MipmapsOption::NoMipmap)
+            .expect("Could not upload texture to GPU");
+        super::Texture(texture)
     }
 }

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -7,6 +7,7 @@ use super::{Index, Vertex2, Vertex3};
 use crate::crash;
 use glium::winit;
 use glium::Surface; // OpenGL interface
+use std::rc::Rc;
 
 mod winit_lifecycle;
 
@@ -129,18 +130,20 @@ pub struct DrawContext<'a> {
     now: std::time::Duration,
 }
 
-glium::implement_vertex!(Vertex3, position, color_multiplier, uv);
+glium::implement_vertex!(Vertex3, position, color_multiplier, texture_coords);
 
-glium::implement_vertex!(Vertex2, position, color_multiplier, uv);
+glium::implement_vertex!(Vertex2, position, color_multiplier, texture_coords);
 
 pub struct Primitive3 {
     vertices: glium::VertexBuffer<Vertex3>,
     indices: glium::IndexBuffer<Index>,
+    texture: Rc<super::Texture>,
 }
 
 pub struct Primitive2 {
     vertices: glium::VertexBuffer<Vertex2>,
     indices: glium::IndexBuffer<Index>,
+    texture: Rc<super::Texture>,
 }
 
 impl super::Drawable for Primitive3 {
@@ -150,20 +153,31 @@ impl super::Drawable for Primitive3 {
         let y = (t * 1.3).sin();
         let s = (t * 2.3).sin() * 0.3 + 0.7;
 
+        let matrix = [
+            [s, 0.0, 0.0, 0.0],
+            [0.0, s, 0.0, 0.0],
+            [0.0, 0.0, s, 0.0],
+            [x * 0.5, y * 0.5, 0.0, 1.0],
+        ];
+        let sampler = self
+            .texture
+            .0
+            .sampled()
+            .minify_filter(glium::uniforms::MinifySamplerFilter::Nearest)
+            .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest);
+
+        let uniforms = glium::uniform! {
+            world_transform: matrix,
+            tex: sampler,
+        };
+
         ctxt.0
             .target
             .draw(
                 &self.vertices,
                 &self.indices,
                 &ctxt.0.gui.program_3d,
-                &glium::uniform! {
-                    world_transform: [
-                        [s, 0.0, 0.0, 0.0],
-                        [0.0, s, 0.0, 0.0],
-                        [0.0, 0.0, s, 0.0],
-                        [x * 0.5, y * 0.5, 0.0, 1.0]
-                    ],
-                },
+                &uniforms,
                 &Default::default(),
             )
             .unwrap();
@@ -181,6 +195,7 @@ impl Gui {
         &mut self,
         vertices: &[Vertex3],
         indices: &[Index],
+        texture: Rc<super::Texture>,
     ) -> Result<super::Primitive3, super::PrimitiveError> {
         // TODO Check validity of indices and length of vertices
 
@@ -194,13 +209,18 @@ impl Gui {
         )
         .expect("Could not create an index buffer");
 
-        Ok(super::Primitive3(Primitive3 { vertices, indices }))
+        Ok(super::Primitive3(Primitive3 {
+            vertices,
+            indices,
+            texture,
+        }))
     }
 
     pub fn make_primitive2(
         &mut self,
         vertices: &[Vertex2],
         indices: &[Index],
+        texture: Rc<super::Texture>,
     ) -> Result<super::Primitive2, super::PrimitiveError> {
         // TODO Check validity of indices and length of vertices
 
@@ -214,7 +234,11 @@ impl Gui {
         )
         .expect("Could not create an index buffer");
 
-        Ok(super::Primitive2(Primitive2 { vertices, indices }))
+        Ok(super::Primitive2(Primitive2 {
+            vertices,
+            indices,
+            texture,
+        }))
     }
 }
 

--- a/src/gui/backend_glium/winit_lifecycle.rs
+++ b/src/gui/backend_glium/winit_lifecycle.rs
@@ -150,18 +150,18 @@ where
             return;
         };
 
-        if gui.0.window.id() != window_id {
+        if gui.backend.window.id() != window_id {
             return;
         }
 
         crate::crash::with_context(("Current winit (GUI) event", || &event), || {
-            gui.0.handle_event(user_app, &event, event_loop);
+            gui.backend.handle_event(user_app, &event, event_loop);
         });
     }
 
     fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
         if let ApplicationState::Running { ref gui, .. } = self.state {
-            gui.0.window.request_redraw();
+            gui.backend.window.request_redraw();
         }
     }
 }

--- a/src/gui/fragment_3d.glsl
+++ b/src/gui/fragment_3d.glsl
@@ -1,8 +1,13 @@
 #version 140
 
 in vec3 color_multiplier_computed;
+
+in vec2 texture_coords_passthru;
+uniform sampler2D tex;
+
 out vec4 color;
 
 void main() {
-    color = vec4(color_multiplier_computed, 1.0);
+    color = texture(tex, texture_coords_passthru);
+    color *= vec4(color_multiplier_computed, 1.0);
 }

--- a/src/gui/vertex_3d.glsl
+++ b/src/gui/vertex_3d.glsl
@@ -2,12 +2,15 @@
 
 in vec3 position;
 in vec3 color_multiplier;
+in vec2 texture_coords;
 
 uniform mat4 world_transform;
 
 out vec3 color_multiplier_computed;
+out vec2 texture_coords_passthru;
 
 void main() {
     gl_Position = world_transform * vec4(position, 1.0);
     color_multiplier_computed = color_multiplier;
+    texture_coords_passthru = texture_coords;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,13 @@ struct MyApplication {
     triangle: gui::Primitive3,
 }
 
+const BLOCK_TEXTURES: gui::TextureGroup = gui::TextureGroup {};
+
 impl MyApplication {
     fn new(gui: &mut gui::Gui) -> Self {
         println!("My init!");
 
-        gui::asset::load_image("test");
+        let texture = gui.texture(BLOCK_TEXTURES.id("test"));
 
         Self {
             triangle: gui

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ impl MyApplication {
     fn new(gui: &mut gui::Gui) -> Self {
         println!("My init!");
 
-        let texture = gui.texture(BLOCK_TEXTURES.id("test"));
+        let _texture = gui.texture(BLOCK_TEXTURES.id("test"));
 
         Self {
             triangle: gui

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,29 +13,35 @@ impl MyApplication {
     fn new(gui: &mut gui::Gui) -> Self {
         println!("My init!");
 
-        let _texture = gui.texture(BLOCK_TEXTURES.id("test"));
+        let texture = gui.texture(BLOCK_TEXTURES.id("test"));
 
         Self {
             triangle: gui
                 .make_primitive3(
                     &[
                         gui::Vertex3 {
-                            position: [0.5, 0.5, 0.0],
-                            color_multiplier: [0.0, 1.0, 1.0],
-                            uv: [0.0, 0.0],
-                        },
-                        gui::Vertex3 {
                             position: [-0.5, 0.5, 0.0],
-                            color_multiplier: [1.0, 0.0, 1.0],
-                            uv: [0.0, 0.0],
+                            color_multiplier: [1.0, 1.0, 1.0],
+                            texture_coords: [0.0, 1.0],
                         },
                         gui::Vertex3 {
-                            position: [0.0, -0.5, 0.0],
-                            color_multiplier: [1.0, 1.0, 0.0],
-                            uv: [0.0, 0.0],
+                            position: [-0.5, -0.5, 0.0],
+                            color_multiplier: [1.0, 1.0, 1.0],
+                            texture_coords: [0.0, 0.0],
+                        },
+                        gui::Vertex3 {
+                            position: [0.5, 0.5, 0.0],
+                            color_multiplier: [1.0, 1.0, 1.0],
+                            texture_coords: [1.0, 1.0],
+                        },
+                        gui::Vertex3 {
+                            position: [0.5, -0.5, 0.0],
+                            color_multiplier: [1.0, 1.0, 1.0],
+                            texture_coords: [1.0, 0.0],
                         },
                     ],
-                    &[0, 1, 2],
+                    &[0, 1, 2, 3, 2, 1],
+                    texture,
                 )
                 .expect("Could not make a triangle"),
         }


### PR DESCRIPTION
This MR adds support for rendering a single texture per `Primitive` and upgrades the example code from a "Hello Triangle" to a "Hello Texture".