### PR TITLE
Add transform stack to DrawContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,8 +451,8 @@ dependencies = [
 
 [[package]]
 name = "glium"
-version = "0.35.0"
-source = "git+https://github.com/OLEGSHA/glium.git?branch=master#ad4dbefc51a44748110fdc7ae3b2feb645722265"
+version = "0.36.0"
+source = "git+https://github.com/OLEGSHA/glium.git?branch=support-all-mat-variants-in-uniforms#9e427dd88f5210da8db0af5539c38c47c7402ece"
 dependencies = [
  "backtrace",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28091a37a5d09b555cb6628fd954da299b536433834f5b8e59eba78e0cbbf8a"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "glium"
 version = "0.35.0"
 source = "git+https://github.com/OLEGSHA/glium.git?branch=master#ad4dbefc51a44748110fdc7ae3b2feb645722265"
@@ -1334,6 +1343,7 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 name = "trapiron"
 version = "0.1.0"
 dependencies = [
+ "glam",
  "glium",
  "image",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+glam = { version = "0.29.0", features = ["bytemuck"] }
 # glium = "0.35"
 glium = { git = "https://github.com/OLEGSHA/glium.git", branch = "master" }
 image = { version = "0.25.2", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 glam = { version = "0.29.0", features = ["bytemuck"] }
-# glium = "0.35"
-glium = { git = "https://github.com/OLEGSHA/glium.git", branch = "master" }
+# glium = "0.36"
+glium = { git = "https://github.com/OLEGSHA/glium.git", branch = "support-all-mat-variants-in-uniforms" }
 image = { version = "0.25.2", default-features = false, features = ["png"] }
 include_dir = { version = "0.7.4", default-features = false }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -210,11 +210,25 @@ impl<'a, 'b, S: DcState> Dcf<'a, 'b, S> {
 pub type Dcf3<'a, 'b> = Dcf<'a, 'b, DcState3>;
 
 impl<'a, 'b> Dcf3<'a, 'b> {
-    /// Returns a frame the applies `transform` before the rest of this frame's _world transform_.
+    /// In a new frame, applies the `transform` to _world transform_.
     ///
     /// See [`Dcf3::apply`] for details.
     pub fn tfed<'c>(&'c mut self, transform: glam::Affine3A) -> Dcf3<'c, 'b> {
         self.apply(|s| s.world_transform *= transform)
+    }
+
+    /// In a new frame, applies a translation such that (0; 0; 0) maps to `new_zero` in this frame.
+    ///
+    /// See [`Dcf3::apply`] for details.
+    pub fn shifted<'c>(&'c mut self, new_zero: glam::Vec3) -> Dcf3<'c, 'b> {
+        self.tfed(glam::Affine3A::from_translation(new_zero))
+    }
+
+    /// In a new frame, scales such that a unit cube has dimentions `new_units` in this frame.
+    ///
+    /// See [`Dcf3::apply`] for details.
+    pub fn scaled<'c>(&'c mut self, new_units: glam::Vec3) -> Dcf3<'c, 'b> {
+        self.tfed(glam::Affine3A::from_scale(new_units))
     }
 }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -55,7 +55,10 @@ impl Gui {
 /// An active render pass.
 ///
 /// A single instance of this object exists while a frame is being rendered.
-pub struct DrawContext<'a>(backend::DrawContext<'a>);
+pub struct DrawContext<'a> {
+    pub gui: &'a mut Gui,
+    backend: backend::DrawContext<'a>,
+}
 
 /// Something that can be rendered.
 pub trait Drawable {

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -141,17 +141,6 @@ pub struct Primitive2 {
 
 impl super::Drawable3 for Primitive3 {
     fn draw(&mut self, dcf: &mut super::Dcf3) {
-        let t = (*dcf.time() - dcf.gui().start_time).as_secs_f32();
-        let x = (t * 1.0).sin();
-        let y = (t * 1.3).sin();
-        let s = (t * 2.3).sin() * 0.3 + 0.7;
-
-        let matrix = [
-            [s, 0.0, 0.0, 0.0],
-            [0.0, s, 0.0, 0.0],
-            [0.0, 0.0, s, 0.0],
-            [x * 0.5, y * 0.5, 0.0, 1.0],
-        ];
         let sampler = self
             .texture
             .0
@@ -159,8 +148,9 @@ impl super::Drawable3 for Primitive3 {
             .minify_filter(glium::uniforms::MinifySamplerFilter::Nearest)
             .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest);
 
+        let jank = glam::Mat4::from(dcf.state.world_transform);
         let uniforms = glium::uniform! {
-            world_transform: matrix,
+            world_transform: jank.to_cols_array_2d(),
             tex: sampler,
         };
 

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -117,7 +117,14 @@ fn process_frame(gui: &mut super::Gui, app: &mut impl super::Application) {
         let mut ctxt = super::DrawContext { gui, backend: ctxt };
 
         ctxt.backend.target.clear_color(0.0, 0.0, 0.0, 1.0);
-        app.draw(&mut ctxt);
+
+        let mut first_frame = super::Dcf {
+            ctxt: &mut ctxt,
+            state: Default::default(),
+        };
+
+        app.draw(&mut first_frame);
+
         ctxt.backend
             .target
             .finish()
@@ -149,8 +156,8 @@ pub struct Primitive2 {
 }
 
 impl super::Drawable for Primitive3 {
-    fn draw(&mut self, ctxt: &mut super::DrawContext) {
-        let t = ctxt.backend.now.as_secs_f32();
+    fn draw(&mut self, dcf: &mut super::Dcf) {
+        let t = dcf.ctxt.backend.now.as_secs_f32();
         let x = (t * 1.0).sin();
         let y = (t * 1.3).sin();
         let s = (t * 2.3).sin() * 0.3 + 0.7;
@@ -173,12 +180,13 @@ impl super::Drawable for Primitive3 {
             tex: sampler,
         };
 
-        ctxt.backend
+        dcf.ctxt
+            .backend
             .target
             .draw(
                 &self.vertices,
                 &self.indices,
-                &ctxt.gui.backend.program_3d,
+                &dcf.ctxt.gui.backend.program_3d,
                 &uniforms,
                 &Default::default(),
             )
@@ -187,7 +195,7 @@ impl super::Drawable for Primitive3 {
 }
 
 impl super::Drawable for Primitive2 {
-    fn draw(&mut self, _ctxt: &mut super::DrawContext) {
+    fn draw(&mut self, _dcf: &mut super::Dcf) {
         unimplemented!();
     }
 }

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -150,6 +150,7 @@ impl super::Drawable3 for Primitive3 {
 
         let uniforms = glium::uniform! {
             world_transform: dcf.state.world_transform.to_cols_array_2d(),
+            color_multiplier_global: dcf.state.color_multiplier.0.to_array(),
             tex: sampler,
         };
 

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -117,14 +117,7 @@ fn process_frame(gui: &mut super::Gui, app: &mut impl super::Application) {
         let mut ctxt = super::DrawContext { gui, backend: ctxt };
 
         ctxt.backend.target.clear_color(0.0, 0.0, 0.0, 1.0);
-
-        let mut first_frame = super::Dcf {
-            ctxt: &mut ctxt,
-            state: Default::default(),
-        };
-
-        app.draw(&mut first_frame);
-
+        app.draw(&mut ctxt);
         ctxt.backend
             .target
             .finish()
@@ -155,8 +148,8 @@ pub struct Primitive2 {
     texture: Rc<super::Texture>,
 }
 
-impl super::Drawable for Primitive3 {
-    fn draw(&mut self, dcf: &mut super::Dcf) {
+impl super::Drawable3 for Primitive3 {
+    fn draw(&mut self, dcf: &mut super::Dcf3) {
         let t = dcf.ctxt.backend.now.as_secs_f32();
         let x = (t * 1.0).sin();
         let y = (t * 1.3).sin();
@@ -194,8 +187,8 @@ impl super::Drawable for Primitive3 {
     }
 }
 
-impl super::Drawable for Primitive2 {
-    fn draw(&mut self, _dcf: &mut super::Dcf) {
+impl super::Drawable2 for Primitive2 {
+    fn draw(&mut self, _dcf: &mut super::Dcf2) {
         unimplemented!();
     }
 }

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -148,9 +148,8 @@ impl super::Drawable3 for Primitive3 {
             .minify_filter(glium::uniforms::MinifySamplerFilter::Nearest)
             .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest);
 
-        let jank = glam::Mat4::from(dcf.state.world_transform);
         let uniforms = glium::uniform! {
-            world_transform: jank.to_cols_array_2d(),
+            world_transform: dcf.state.world_transform.to_cols_array_2d(),
             tex: sampler,
         };
 

--- a/src/gui/backend_glium/winit_lifecycle.rs
+++ b/src/gui/backend_glium/winit_lifecycle.rs
@@ -155,7 +155,7 @@ where
         }
 
         crate::crash::with_context(("Current winit (GUI) event", || &event), || {
-            gui.backend.handle_event(user_app, &event, event_loop);
+            super::handle_event(gui, user_app, &event, event_loop);
         });
     }
 

--- a/src/gui/vertex_3d.glsl
+++ b/src/gui/vertex_3d.glsl
@@ -4,13 +4,13 @@ in vec3 position;
 in vec3 color_multiplier;
 in vec2 texture_coords;
 
-uniform mat4 world_transform;
+uniform mat4x3 world_transform;
 
 out vec3 color_multiplier_computed;
 out vec2 texture_coords_passthru;
 
 void main() {
-    gl_Position = world_transform * vec4(position, 1.0);
+    gl_Position = vec4(world_transform * vec4(position, 1.0), 1.0);
     color_multiplier_computed = color_multiplier;
     texture_coords_passthru = texture_coords;
 }

--- a/src/gui/vertex_3d.glsl
+++ b/src/gui/vertex_3d.glsl
@@ -5,12 +5,13 @@ in vec3 color_multiplier;
 in vec2 texture_coords;
 
 uniform mat4x3 world_transform;
+uniform vec3 color_multiplier_global;
 
 out vec3 color_multiplier_computed;
 out vec2 texture_coords_passthru;
 
 void main() {
     gl_Position = vec4(world_transform * vec4(position, 1.0), 1.0);
-    color_multiplier_computed = color_multiplier;
+    color_multiplier_computed = color_multiplier * color_multiplier_global;
     texture_coords_passthru = texture_coords;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,20 @@ impl MyApplication {
     }
 }
 
+fn draw_bouncy(object: &mut impl gui::Drawable3, t: f32, dcf: &mut gui::Dcf3) {
+    // Move in screen space
+    let mut dcf = dcf.shifted(Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0));
+    object.draw(&mut dcf.colored(&gui::OpaqueColor::rgb(Vec3::splat(0.1))));
+
+    // Slow pulsing
+    let mut dcf = dcf.scaled(Vec3::splat((t * 2.3).sin() * 0.3 + 0.7));
+    object.draw(&mut dcf.colored(&gui::OpaqueColor::rgb(Vec3::splat(0.3))));
+
+    // Fast wobble (demonstrates that move is not influenced by scale)
+    let mut dcf = dcf.scaled(Vec3::new((t * 20.0).sin() * 0.1 + 0.9, 1.0, 1.0));
+    object.draw(&mut dcf);
+}
+
 impl gui::Application for MyApplication {
     fn draw(&mut self, ctxt: &mut gui::DrawContext) {
         let mut dcf = ctxt.start_3();
@@ -60,20 +74,18 @@ impl gui::Application for MyApplication {
         let t = self.animation_start.get_or_insert(*dcf.time());
         let t = (*dcf.time() - *t).as_secs_f32();
 
-        let transform = Affine3A::from_scale_rotation_translation(
-            Vec3::splat((t * 2.3).sin() * 0.3 + 0.7),
-            Default::default(),
-            Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0),
-        );
+        let blue = gui::OpaqueColor::rgb(Vec3::new(0.0, 0.1, 0.9));
+        let green = gui::OpaqueColor::rgb(Vec3::new(0.05, 0.8, 0.1));
 
-        self.rect.draw(
+        draw_bouncy(&mut self.rect, -t, &mut dcf.colored(&blue));
+        draw_bouncy(&mut self.rect, t, &mut dcf);
+        draw_bouncy(
+            &mut self.rect,
+            t * 5.0,
             &mut dcf
-                // Move in screen space
-                .shifted(Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0))
-                // Slow pulsing
-                .scaled(Vec3::splat((t * 2.3).sin() * 0.3 + 0.7))
-                // Fast wobble (demonstrates that move is not influenced by scale)
-                .scaled(Vec3::new((t * 20.0).sin() * 0.1 + 0.9, 1.0, 1.0)),
+                .shifted(Vec3::new(0.9, 0.9, 0.0))
+                .scaled(Vec3::splat(0.1))
+                .colored(&green),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![feature(get_mut_unchecked)]
 
+use glam::{Affine3A, Vec3};
+
 mod crash;
 mod gui;
 
@@ -52,12 +54,8 @@ impl gui::Application for MyApplication {}
 
 impl gui::Drawable for MyApplication {
     fn draw(&mut self, dcf: &mut gui::Dcf) {
-        let mut f1 = dcf.apply(|s| *s += 1);
-        let mut _f2 = f1.apply(|s| *s *= 10);
-
-        f1.state();
-
-        self.triangle.draw(&mut f1);
+        self.triangle
+            .draw(&mut dcf.tfed(Affine3A::from_scale(Vec3::new(1f32, 0.5, 1f32))));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod crash;
 mod gui;
 
 struct MyApplication {
-    triangle: gui::Primitive3,
+    rect: gui::Primitive3,
     animation_start: Option<std::time::Instant>,
 }
 
@@ -20,7 +20,7 @@ impl MyApplication {
         let texture = gui.texture(BLOCK_TEXTURES.id("test"));
 
         Self {
-            triangle: gui
+            rect: gui
                 .make_primitive3(
                     &[
                         gui::Vertex3 {
@@ -47,7 +47,7 @@ impl MyApplication {
                     &[0, 1, 2, 3, 2, 1],
                     texture,
                 )
-                .expect("Could not make a triangle"),
+                .expect("Could not make a rectangle"),
             animation_start: None,
         }
     }
@@ -57,9 +57,7 @@ impl gui::Application for MyApplication {
     fn draw(&mut self, ctxt: &mut gui::DrawContext) {
         let mut dcf = ctxt.start_3();
 
-        let t = self
-            .animation_start
-            .get_or_insert_with(|| std::time::Instant::now());
+        let t = self.animation_start.get_or_insert(*dcf.time());
         let t = (*dcf.time() - *t).as_secs_f32();
 
         let transform = Affine3A::from_scale_rotation_translation(
@@ -68,7 +66,7 @@ impl gui::Application for MyApplication {
             Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0),
         );
 
-        self.triangle.draw(&mut dcf.tfed(transform));
+        self.rect.draw(&mut dcf.tfed(transform));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,13 @@ impl MyApplication {
 impl gui::Application for MyApplication {}
 
 impl gui::Drawable for MyApplication {
-    fn draw(&mut self, ctxt: &mut gui::DrawContext) {
-        self.triangle.draw(ctxt);
+    fn draw(&mut self, dcf: &mut gui::Dcf) {
+        let mut f1 = dcf.apply(|s| *s += 1);
+        let mut _f2 = f1.apply(|s| *s *= 10);
+
+        f1.state();
+
+        self.triangle.draw(&mut f1);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod gui;
 
 struct MyApplication {
     triangle: gui::Primitive3,
+    animation_start: Option<std::time::Instant>,
 }
 
 const BLOCK_TEXTURES: gui::TextureGroup = gui::TextureGroup {};
@@ -47,6 +48,7 @@ impl MyApplication {
                     texture,
                 )
                 .expect("Could not make a triangle"),
+            animation_start: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(get_mut_unchecked)]
 
+use crate::gui::Drawable3;
 use glam::{Affine3A, Vec3};
 
 mod crash;
@@ -50,10 +51,9 @@ impl MyApplication {
     }
 }
 
-impl gui::Application for MyApplication {}
-
-impl gui::Drawable for MyApplication {
-    fn draw(&mut self, dcf: &mut gui::Dcf) {
+impl gui::Application for MyApplication {
+    fn draw(&mut self, ctxt: &mut gui::DrawContext) {
+        let mut dcf = ctxt.start_3();
         self.triangle
             .draw(&mut dcf.tfed(Affine3A::from_scale(Vec3::new(1f32, 0.5, 1f32))));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,19 @@ impl MyApplication {
 impl gui::Application for MyApplication {
     fn draw(&mut self, ctxt: &mut gui::DrawContext) {
         let mut dcf = ctxt.start_3();
-        self.triangle
-            .draw(&mut dcf.tfed(Affine3A::from_scale(Vec3::new(1f32, 0.5, 1f32))));
+
+        let t = self
+            .animation_start
+            .get_or_insert_with(|| std::time::Instant::now());
+        let t = (*dcf.time() - *t).as_secs_f32();
+
+        let transform = Affine3A::from_scale_rotation_translation(
+            Vec3::splat((t * 2.3).sin() * 0.3 + 0.7),
+            Default::default(),
+            Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0),
+        );
+
+        self.triangle.draw(&mut dcf.tfed(transform));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,15 @@ impl gui::Application for MyApplication {
             Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0),
         );
 
-        self.rect.draw(&mut dcf.tfed(transform));
+        self.rect.draw(
+            &mut dcf
+                // Move in screen space
+                .shifted(Vec3::new((t * 1.0).sin() / 2.0, (t * 1.3).sin() / 2.0, 1.0))
+                // Slow pulsing
+                .scaled(Vec3::splat((t * 2.3).sin() * 0.3 + 0.7))
+                // Fast wobble (demonstrates that move is not influenced by scale)
+                .scaled(Vec3::new((t * 20.0).sin() * 0.1 + 0.9, 1.0, 1.0)),
+        );
     }
 }
 


### PR DESCRIPTION
Introduces `Dcf` (Draw Context Frame): a DrawContext paired with specific draw settings (GLSL uniform values). Adds ability to modify `world_transform` via `Dcf`.

The core feature of Dcf is that they can nest, and Rust borrow checker is used to ensure that parent Dcfs cannot be used while child Dcfs still exist. When a child Dcf is created, it effectively "pushes" a new set of settings into the "state stack", and the changes are undone when it is dropped. This mechanism parallels the obsolete `glPushMatrix` / `glPopMatrix` mechanism in legacy OpenGL, allowing inner code to transparently use settings configured by outer code.

This mechanism is expected to be reused for a few parameters, not just world transforms. However, parameters that are not expected to change during render, such as camera transform or screen transform, will likely not use frames.