### PR TITLE
Add 3D camera and depth testing

### DIFF
--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -142,6 +142,8 @@ impl super::Drawable for Primitive {
             .magnify_filter(glium::uniforms::MagnifySamplerFilter::Nearest);
 
         let uniforms = glium::uniform! {
+            screen_transform: dcf.settings().screen_transform.to_cols_array_2d(),
+            view_transform: dcf.settings().view_transform.to_cols_array_2d(),
             world_transform: dcf.state().world_transform.to_cols_array_2d(),
             color_multiplier_global: dcf.state().color_multiplier.0.to_array(),
             tex: sampler,

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -97,6 +97,10 @@ fn process_frame(gui: &mut super::Gui, app: &mut impl super::Application) {
 
     let frame_number = gui.last_started_frame;
     crash::with_context(("Current frame", || frame_number), || {
+        let size = gui.backend.window.inner_size();
+        let scale = gui.backend.window.scale_factor() as f32;
+        let size = glam::Vec2::new(size.width as f32 / scale, size.height as f32 / scale);
+
         let ctxt = DrawContext {
             target: gui.backend.display.draw(),
             _phantom: std::marker::PhantomData,
@@ -105,6 +109,7 @@ fn process_frame(gui: &mut super::Gui, app: &mut impl super::Application) {
         let mut ctxt = super::draw::Context {
             gui,
             backend: ctxt,
+            size,
             time: std::time::Instant::now(),
             settings: Default::default(),
         };

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -162,6 +162,7 @@ impl super::Drawable for Primitive {
                 write: true,
                 ..Default::default()
             },
+            backface_culling: glium::draw_parameters::BackfaceCullingMode::CullClockwise,
             ..Default::default()
         };
 

--- a/src/gui/backend_glium.rs
+++ b/src/gui/backend_glium.rs
@@ -109,7 +109,9 @@ fn process_frame(gui: &mut super::Gui, app: &mut impl super::Application) {
             settings: Default::default(),
         };
 
-        ctxt.backend.target.clear_color(0.0, 0.0, 0.0, 1.0);
+        ctxt.backend
+            .target
+            .clear_color_and_depth((0.0, 0.0, 0.0, 1.0), 1.0);
         app.draw(&mut super::Dcf::new(&mut ctxt));
         ctxt.backend
             .target
@@ -149,6 +151,15 @@ impl super::Drawable for Primitive {
             tex: sampler,
         };
 
+        let params = glium::DrawParameters {
+            depth: glium::Depth {
+                test: glium::draw_parameters::DepthTest::IfLess,
+                write: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
         dcf.ctxt
             .backend
             .target
@@ -157,7 +168,7 @@ impl super::Drawable for Primitive {
                 &self.indices,
                 &dcf.ctxt.gui.backend.program,
                 &uniforms,
-                &Default::default(),
+                &params,
             )
             .unwrap();
     }

--- a/src/gui/backend_glium/shader/vertex.glsl
+++ b/src/gui/backend_glium/shader/vertex.glsl
@@ -4,6 +4,8 @@ in vec3 position;
 in vec3 color_multiplier;
 in vec2 texture_coords;
 
+uniform mat4 screen_transform;
+uniform mat4x3 view_transform;
 uniform mat4x3 world_transform;
 uniform vec3 color_multiplier_global;
 
@@ -11,7 +13,11 @@ out vec3 color_multiplier_computed;
 out vec2 texture_coords_passthru;
 
 void main() {
-    gl_Position = vec4(world_transform * vec4(position, 1.0), 1.0);
+    gl_Position = vec4(position, 1.0);
+    gl_Position = vec4(world_transform * gl_Position, 1.0);
+    gl_Position = vec4(view_transform * gl_Position, 1.0);
+    gl_Position = screen_transform * gl_Position;
+
     color_multiplier_computed = color_multiplier * color_multiplier_global;
     texture_coords_passthru = texture_coords;
 }

--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -9,7 +9,7 @@
 //!       render resources.
 
 use super::{Gui, OpaqueColor};
-use glam::{Affine3A, Vec3};
+use glam::{Affine3A, Mat4, Vec3};
 
 /// An active render operation.
 ///
@@ -182,7 +182,17 @@ impl<'a, 'b> Dcf<'a, 'b> {
 /// rendered, though they may change once or twice.
 #[derive(Clone, Default)]
 pub struct Settings {
-    // Empty for now; will contain view transform and lighting settings.
+    /// The transform from world coordinates to view coordinates.
+    ///
+    /// The inverse of the camera pose. This value is ignored for lighting computations.
+    pub view_transform: Affine3A,
+
+    /// The transform from view coordinates to screen coordinates; normally an orthographic or a
+    /// perspective projection.
+    ///
+    /// Transforms 3D camera-centric coordinates to 2D screen-based normalized coordinates in the
+    /// [-1;+1] range for X and Y.
+    pub screen_transform: Mat4,
 }
 
 /// Something that can be rendered onto the screen.

--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -112,6 +112,14 @@ impl<'a, 'b> Dcf<'a, 'b> {
         }
     }
 
+    /// Ensures that previous draw operations do not interfere with future requests due to depth
+    /// testing.
+    ///
+    /// The effect of this command is not limited to this [`Dcf`] value.
+    pub fn start_next_layer(&mut self) {
+        // TODO: relay request to backend (clear depth buffer? increase depth padding?)
+    }
+
     /// Returns the time instant that draw logic should use.
     pub fn time(&self) -> &std::time::Instant {
         &self.ctxt.time

--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -112,14 +112,6 @@ impl<'a, 'b> Dcf<'a, 'b> {
         }
     }
 
-    /// Ensures that previous draw operations do not interfere with future requests due to depth
-    /// testing.
-    ///
-    /// The effect of this command is not limited to this [`Dcf`] value.
-    pub fn start_next_layer(&mut self) {
-        // TODO: relay request to backend (clear depth buffer? increase depth padding?)
-    }
-
     /// Returns the time instant that draw logic should use.
     pub fn time(&self) -> &std::time::Instant {
         &self.ctxt.time

--- a/src/gui/draw.rs
+++ b/src/gui/draw.rs
@@ -9,7 +9,7 @@
 //!       render resources.
 
 use super::{Gui, OpaqueColor};
-use glam::{Affine3A, Mat4, Vec3};
+use glam::{Affine3A, Mat4, Vec2, Vec3};
 
 /// An active render operation.
 ///
@@ -20,6 +20,11 @@ pub(super) struct Context<'a> {
 
     /// The implementation provided by the backend.
     pub backend: super::backend::DrawContext<'a>,
+
+    /// The viewport size for this frame.
+    ///
+    /// See [`Dcf::size`] for a more specific definition.
+    pub size: Vec2,
 
     /// The time moment that draw logic should use for this frame.
     pub time: std::time::Instant,
@@ -110,6 +115,15 @@ impl<'a, 'b> Dcf<'a, 'b> {
     /// Returns the time instant that draw logic should use.
     pub fn time(&self) -> &std::time::Instant {
         &self.ctxt.time
+    }
+
+    /// Returns the size of the viewport in pixels that draw logic should use.
+    ///
+    /// Returns the size of the renderable area ("window client area", "clip space", "viewport")
+    /// measured in logical pixels (not necessarily physical display pixels). The dimensions are
+    /// positive but not necessarily integer values.
+    pub fn size(&self) -> Vec2 {
+        self.ctxt.size
     }
 
     /// Returns a reference to the [`Gui`] instance.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,17 @@ impl MyApplication {
 }
 
 fn draw_spinning(object: &mut impl gui::Drawable, t: f32, dcf: &mut gui::Dcf) {
-    object.draw(&mut dcf.tfed(Affine3A::from_rotation_y(t)).shifted(Vec3::X));
+    let dark = gui::OpaqueColor::rgb(Vec3::new(0.1, 0.1, 0.15));
+
+    let mut dcf = dcf.tfed(Affine3A::from_rotation_y(t));
+    let mut dcf = dcf.shifted(Vec3::X);
+
+    object.draw(&mut dcf);
+    object.draw(
+        &mut dcf
+            .tfed(Affine3A::from_rotation_y(180f32.to_radians()))
+            .colored(&dark),
+    );
 }
 
 impl gui::Application for MyApplication {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,10 +62,11 @@ impl gui::Drawable for MyApplication {
     fn draw(&mut self, dcf: &mut gui::Dcf) {
         let mut new_settings = dcf.settings().clone();
 
-        new_settings.view_transform =
-            Affine3A::look_at_lh(Vec3::new(0f32, 0f32, -5f32), Vec3::ZERO, Vec3::Y);
+        let fov = 75f32.to_radians();
         new_settings.screen_transform =
-            Mat4::perspective_lh(std::f32::consts::PI / 2.5, 1f32, 0.01f32, 100f32);
+            Mat4::perspective_lh(fov, dcf.size().x / dcf.size().y, 0.01, 100.0);
+
+        new_settings.view_transform = Affine3A::look_at_lh(Vec3::Z * -2.5, Vec3::ZERO, Vec3::Y);
 
         dcf.set_settings(new_settings);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(get_mut_unchecked)]
 
-use glam::{Affine3A, Vec3};
+use glam::{Affine3A, Mat4, Vec3};
 
 pub mod crash;
 pub mod gui;
@@ -60,9 +60,13 @@ impl gui::Application for MyApplication {}
 
 impl gui::Drawable for MyApplication {
     fn draw(&mut self, dcf: &mut gui::Dcf) {
-        let old_settings = dcf.settings();
-        let new_settings = old_settings.clone();
-        // new_settings
+        let mut new_settings = dcf.settings().clone();
+
+        new_settings.view_transform =
+            Affine3A::look_at_lh(Vec3::new(0f32, 0f32, -5f32), Vec3::ZERO, Vec3::Y);
+        new_settings.screen_transform =
+            Mat4::perspective_lh(std::f32::consts::PI / 2.5, 1f32, 0.01f32, 100f32);
+
         dcf.set_settings(new_settings);
 
         let t = self.animation_start.get_or_insert(*dcf.time());

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,17 @@ fn draw_spinning(object: &mut impl gui::Drawable, t: f32, dcf: &mut gui::Dcf) {
     );
 }
 
+fn remap_depth(new_min: gui::Float, new_max: gui::Float) -> Mat4 {
+    let mul = new_max - new_min;
+    let add = new_min;
+    Mat4::from_cols_array_2d(&[
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, mul, 0.0],
+        [0.0, 0.0, add, 1.0],
+    ])
+}
+
 impl gui::Application for MyApplication {}
 
 impl gui::Drawable for MyApplication {
@@ -75,8 +86,8 @@ impl gui::Drawable for MyApplication {
         let mut new_settings = dcf.settings().clone();
 
         let fov = 75f32.to_radians();
-        new_settings.screen_transform =
-            Mat4::perspective_lh(fov, dcf.size().x / dcf.size().y, 0.01, 100.0);
+        new_settings.screen_transform = remap_depth(0.1, 1.0) // takes up Z values 1.0 -> 0.1
+            * Mat4::perspective_lh(fov, dcf.size().x / dcf.size().y, 0.01, 100.0);
 
         new_settings.view_transform = Affine3A::look_at_lh(Vec3::Z * -2.5, Vec3::ZERO, Vec3::Y);
 
@@ -94,12 +105,10 @@ impl gui::Drawable for MyApplication {
 
         // Draw 2D overlay
 
-        dcf.start_next_layer();
-
         let mut new_settings = dcf.settings().clone();
 
-        new_settings.screen_transform =
-            Mat4::orthographic_lh(0.0, dcf.size().x, 0.0, dcf.size().y, 0.0, 1.0);
+        new_settings.screen_transform = remap_depth(0.0, 0.1) // takes up Z values 0.1 -> 0.0
+            * Mat4::orthographic_lh(0.0, dcf.size().x, 0.0, dcf.size().y, 0.0, 1.0);
         new_settings.view_transform = Affine3A::IDENTITY;
 
         dcf.set_settings(new_settings);

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,8 @@ impl gui::Application for MyApplication {}
 
 impl gui::Drawable for MyApplication {
     fn draw(&mut self, dcf: &mut gui::Dcf) {
+        // Draw 3D scene
+
         let mut new_settings = dcf.settings().clone();
 
         let fov = 75f32.to_radians();
@@ -89,6 +91,24 @@ impl gui::Drawable for MyApplication {
         draw_spinning(&mut self.rect, t * 1.0, &mut dcf.colored(&blue));
         draw_spinning(&mut self.rect, t * 1.5, dcf);
         draw_spinning(&mut self.rect, t * 0.8, &mut dcf.colored(&green));
+
+        // Draw 2D overlay
+
+        dcf.start_next_layer();
+
+        let mut new_settings = dcf.settings().clone();
+
+        new_settings.screen_transform =
+            Mat4::orthographic_lh(0.0, dcf.size().x, 0.0, dcf.size().y, 0.0, 1.0);
+        new_settings.view_transform = Affine3A::IDENTITY;
+
+        dcf.set_settings(new_settings);
+
+        self.rect.draw(
+            &mut dcf
+                .shifted(Vec3::new(48.0, 48.0, 0.0))
+                .scaled(Vec3::splat(48.0 * 2.0)),
+        );
     }
 }
 


### PR DESCRIPTION
Adds 3D rendering concepts of view transform, screen transform and implements depth testing.

![image](https://github.com/user-attachments/assets/570294e7-f279-4ac7-85a6-ad0f8a63a652)

## Scope limitation

The current API for `draw::Settings` and especially depth remapping is rather inconvenient and does not use RAII principles. While this will have to be rectified as some point, I would prefer to wait until a sufficiently complex use case comes up before making further design decisions and refactoring.